### PR TITLE
Add workflow to publish test dashboard to GitHub Pages

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -1,0 +1,45 @@
+name: Dashboard
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install -r requirements.txt pytest
+      - name: Generate dashboard
+        run: python scripts/generate_dashboard.py
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: dashboard
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ output/
 videos.db
 app.log
 assets/
+dashboard/

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -1,0 +1,17 @@
+import subprocess
+import html
+from pathlib import Path
+
+def main() -> int:
+    result = subprocess.run(["pytest", "-q"], capture_output=True, text=True)
+    output = result.stdout + ("\n" + result.stderr if result.stderr else "")
+    dashboard_dir = Path("dashboard")
+    dashboard_dir.mkdir(exist_ok=True)
+    with open(dashboard_dir / "index.html", "w", encoding="utf-8") as fh:
+        fh.write("<html><body><h1>Test Results</h1><pre>")
+        fh.write(html.escape(output))
+        fh.write("</pre></body></html>")
+    return result.returncode
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- generate dashboard HTML from test run
- add GitHub Actions workflow to deploy dashboard to Pages
- ignore generated dashboard directory

## Testing
- `pytest`
- `python scripts/generate_dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_68b24954ca0c8325a5e9eec91891ad8c